### PR TITLE
Add configurable cost for declaring war (#59)

### DIFF
--- a/TownsAndNations-Common/src/main/java/org/leralix/tan/gui/user/territory/DeclareWarMenu.java
+++ b/TownsAndNations-Common/src/main/java/org/leralix/tan/gui/user/territory/DeclareWarMenu.java
@@ -65,19 +65,29 @@ public class DeclareWarMenu extends IteratorGUI {
 
                     int nbAllies = iterateTerritory.getRelations().getTerritoriesIDWithRelation(TownRelation.ALLIANCE).size();
 
-                    List<FilledLang> confirmDescription = List.of(
+                    List<FilledLang> confirmDescription = new ArrayList<>();
+
+                    confirmDescription.add(
                             Lang.DECLARE_WAR_CONFIRM_MESSAGE.get(
                                     territoryData.getColoredName(),
                                     iterateTerritory.getColoredName()
-                            ),
+                            )
+                    );
+                    confirmDescription.add(
                             Lang.DECLARE_WAR_NUMBER_OF_ALLIES.get(
                                     iterateTerritory.getColoredName(),
                                     Integer.toString(nbAllies)
-                            ),
-                            Lang.REQUIREMENT_COST_POSITIVE.get(
-                                    Integer.toString(Constants.getWarDeclareCost())
                             )
                     );
+
+                    if (Constants.getWarDeclareCost() > 0) {
+                        confirmDescription.add(
+                                Lang.REQUIREMENT_COST_POSITIVE.get(
+                                        Integer.toString(Constants.getWarDeclareCost())
+                                )
+                        );
+                    }
+
 
                     new ConfirmMenu(
                             player,

--- a/TownsAndNations-Common/src/main/java/org/leralix/tan/gui/user/territory/DeclareWarMenu.java
+++ b/TownsAndNations-Common/src/main/java/org/leralix/tan/gui/user/territory/DeclareWarMenu.java
@@ -9,10 +9,12 @@ import org.leralix.tan.data.territory.relation.TownRelation;
 import org.leralix.tan.gui.BasicGui;
 import org.leralix.tan.gui.IteratorGUI;
 import org.leralix.tan.gui.common.ConfirmMenu;
+import org.leralix.tan.gui.service.requirements.MoneyRequirement;
 import org.leralix.tan.gui.user.war.WarMenuDispatch;
 import org.leralix.tan.lang.FilledLang;
 import org.leralix.tan.lang.Lang;
 import org.leralix.tan.storage.stored.WarStorage;
+import org.leralix.tan.utils.constants.Constants;
 import org.leralix.tan.utils.gameplay.TerritoryUtil;
 import org.leralix.tan.utils.text.TanChatUtils;
 import org.leralix.tan.war.War;
@@ -71,6 +73,9 @@ public class DeclareWarMenu extends IteratorGUI {
                             Lang.DECLARE_WAR_NUMBER_OF_ALLIES.get(
                                     iterateTerritory.getColoredName(),
                                     Integer.toString(nbAllies)
+                            ),
+                            Lang.REQUIREMENT_COST_POSITIVE.get(
+                                    Integer.toString(Constants.getWarDeclareCost())
                             )
                     );
 
@@ -78,6 +83,18 @@ public class DeclareWarMenu extends IteratorGUI {
                             player,
                             confirmDescription,
                             () -> {
+                                MoneyRequirement requirement =
+                                        new MoneyRequirement(territoryData, Constants.getWarDeclareCost());
+                                if (requirement.isInvalid()) {
+                                    TanChatUtils.message(player, requirement.getLine(langType), SoundEnum.NOT_ALLOWED);
+                                    SoundUtil.playSound(player, SoundEnum.NOT_ALLOWED);
+                                    return;
+                                }
+
+                                requirement.actionDone();
+
+                                SoundUtil.playSound(player, SoundEnum.WAR);
+
                                 War newWar = warStorage.newWar(territoryData, iterateTerritory);
                                 WarMenuDispatch.openMenu(player, newWar, territoryData);
                             },

--- a/TownsAndNations-Common/src/main/java/org/leralix/tan/utils/constants/Constants.java
+++ b/TownsAndNations-Common/src/main/java/org/leralix/tan/utils/constants/Constants.java
@@ -102,6 +102,7 @@ public class Constants {
 
     //Wars
     private static boolean simpleWarMode;
+    private static int warDeclareCost;
     private static boolean enableLeavingWars;
     private static WarTimeSlot warTimeSlot;
     private static double warBoundaryRadius;
@@ -244,6 +245,7 @@ public class Constants {
 
         //Attacks
         simpleWarMode = config.getBoolean("simpleWarMode");
+        warDeclareCost = config.getInt("warDeclareCost", 1000);
         enableLeavingWars = config.getBoolean("enableLeavingWars", true);
         warTimeSlot = new WarTimeSlot(
                 config.getStringList("allowedTimeSlotsWar"),
@@ -706,6 +708,10 @@ public class Constants {
 
     public static PermissionAtWars getPermissionAtWars() {
         return permissionAtWars;
+    }
+
+    public static int getWarDeclareCost() {
+        return warDeclareCost;
     }
 
     public static List<String> getPerPlayerEndCommands() {

--- a/TownsAndNations-Common/src/main/resources/config.yml
+++ b/TownsAndNations-Common/src/main/resources/config.yml
@@ -318,6 +318,9 @@ RankNameSize: 25
 #Enable war
 EnableWar: true
 
+#WarDeclareCost
+warDeclareCost: 1000
+
 # Simple war mode
 # If enabled, a war will not require attacks to capture chunks.
 # As soon as the war is declared, an attack will start and last until one side surrenders.


### PR DESCRIPTION
### Summary
This PR adds a configurable cost for declaring wars.

<img width="1392" height="880" alt="2026-03-08 160319" src="https://github.com/user-attachments/assets/675fdbf5-c18b-4e39-a989-1044f8336db0" />

### Changes
- Added warDeclareCost configuration option (default: 1000g)
- Implemented cost validation using MoneyRequirement before creating a war
- Deducts the cost from the attacking territory when the war is declared
- Displays the war declaration cost in the confirmation GUI
- Plays a sound when the player cannot afford the war cost

### Result
Players must now pay the configured amount before declaring a war, preventing free war declarations while keeping the cost configurable through the plugin configuration.

Closes #59