### PR TITLE
Bug: Setting CHUNK_CAP to infinity results in DELETE_EACH_DAY to zero chunks for territories

### DIFF
--- a/TownsAndNations-Common/src/main/java/org/leralix/tan/data/territory/TerritoryData.java
+++ b/TownsAndNations-Common/src/main/java/org/leralix/tan/data/territory/TerritoryData.java
@@ -789,8 +789,12 @@ public abstract class TerritoryData implements TanTerritory, Territory {
         paySalaries();
 
         int numberClaimedChunk = getNumberOfClaimedChunk();
-        int maxAmount = getNewLevel().getStat(ChunkCap.class).getMaxAmount();
-        if (numberClaimedChunk > maxAmount) {
+        
+        ChunkCap territoryChunkStat = getNewLevel().getStat(ChunkCap.class);
+
+        int maxAmount = territoryChunkStat.getMaxAmount();
+        boolean isUnlimited = territoryChunkStat.isUnlimited();
+        if (isUnlimited == false && numberClaimedChunk > maxAmount) {
             int chunkToDelete = numberClaimedChunk - maxAmount;
             switch (Constants.getChunkCapExceededStrategy()){
                 case DELETE_INSTANT -> deletePortionOfChunk(chunkToDelete, 0);


### PR DESCRIPTION
When the chunk cap is set to "infinite" in the upgrades.yml for a territory, the max number of chunk claims (getMaxAmount()) is set to 0 and unlimited chunk claims (isUnlimited()) set to true. This is not considered in the daily unclaiming behaviour for territories beyond the chunk cap and results in territories being gradually unclaimed to zero chunks.